### PR TITLE
GA tag patch (remove hardcoded BRP tag and make tag inclusion depende…

### DIFF
--- a/apps/common/views/layout.html
+++ b/apps/common/views/layout.html
@@ -26,18 +26,8 @@
       {{> partials-maincontent-left}}
     </div>
 
-    <script type="text/javascript">
-      var _gaq = _gaq || [];
-      _gaq.push(['_setAccount', 'UA-65423788-1']);
-      _gaq.push(['_trackPageview']);
-
-      (function() {
-        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-      })();
-
-    </script>
+     {{> partials-gatag}}
+    
     <script type="text/javascript" src="/public/js/bundle.js"></script>
   </main>
 {{/main}}

--- a/apps/common/views/partials/gatag.html
+++ b/apps/common/views/partials/gatag.html
@@ -1,0 +1,12 @@
+
+{{#gaTagId}}
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      
+      ga('create', '{{gaTagId}}', 'auto');
+      ga('send', 'pageview');
+    </script>
+{{/gaTagId}}


### PR DESCRIPTION
…nt on env)

Repos forked from hof-example-form are polluting the BRP GA tag analytics - see https://github.com/UKHomeOffice/hof-example-form/issues/18

This patch removes the hard-coded tag script and includes only if the tag id is exposed as a local.