### PR TITLE
SD 110: 'Start Again' button after session timeout fails

### DIFF
--- a/apps/common/views/error.html
+++ b/apps/common/views/error.html
@@ -6,7 +6,7 @@
 
 {{$content}}
     <p>{{content.message}}</p>
-    <a href="/{{startLink}}" class="button" role="button">Start again</a>
+    <a href="{{startLink}}" class="button" role="button">Start again</a>
     {{#showStack}}
       <pre>
         {{error.stack}}

--- a/errors/index.js
+++ b/errors/index.js
@@ -29,6 +29,6 @@ module.exports = function errorHandler(err, req, res, next) {
     error: err,
     content: content,
     showStack: config.env === 'development',
-    startLink: req.path.replace(/^\/([^\/]*).*$/, '$1')
+    startLink: '/'
   });
 };


### PR DESCRIPTION
[https://collaboration.homeoffice.gov.uk/jira/browse/SD-110]

What: Removed the '/' from the start again href.

Why: This was breaking the link provided and preventing the application returning to the start of the journey.