### PR TITLE
SD-767 and SD-822: Session-expiry-message and H1-empty-heading

### DIFF
--- a/apps/are_form/translations/src/en/errors.json
+++ b/apps/are_form/translations/src/en/errors.json
@@ -5,6 +5,6 @@
   },
   "session": {
     "title": "Sorry, you'll have to start again",
-    "message": "You haven't entered any details for 20 minutes, so we have cleared your information to keep it secure."
+    "message": "You haven't entered any details for 30 minutes, so we have cleared your information to keep it secure."
   }
 }

--- a/apps/are_form/views/result.html
+++ b/apps/are_form/views/result.html
@@ -11,12 +11,13 @@
 {{> partials-navigation}}
 {{/propositionHeader}}
 
+{{$header}}{{#t}}pages.result.header{{/t}}{{/header}}
+
 {{$content}}
 
 {{<partials-form}}
 
 {{$form}}
-<h1>{{#t}}pages.result.header{{/t}}</h1>
 <div class="highlighted-result">
   <h1><B>{{values.are-date}}</B></h1>
 

--- a/apps/are_form/views/session-timeout.html
+++ b/apps/are_form/views/session-timeout.html
@@ -1,0 +1,10 @@
+{{<error}}
+    {{$header}}
+        {{#t}}errors.session.title{{/t}}
+    {{/header}}
+
+    {{$content}}
+        <p>{{#t}}errors.session.message{{/t}}</p>
+        <a href="{{startLink}}" class="button" role="button">{{#t}}buttons.start-again{{/t}}</a>
+    {{/content}}
+{{/error}}


### PR DESCRIPTION
**Jira Tickets:** 

https://collaboration.homeoffice.gov.uk/jira/browse/SD-767
https://collaboration.homeoffice.gov.uk/jira/browse/SD-822

**Changes**

- session-timeout.html page added
- errors.json corrected to show timeout message being 30 minutes
- Changed header in result.html file, to remove empty heading.