### PR TITLE
ARE-97: add new CSP rules to service config

### DIFF
--- a/server.js
+++ b/server.js
@@ -12,7 +12,19 @@ settings = Object.assign({}, settings, {
   routes: settings.routes.map(require),
   getCookies: false,
   getTerms: false,
-  getAccessibility: false
+  getAccessibility: false,
+  csp: {
+    imgSrc: [
+      'www.google-analytics.com',
+      'ssl.gstatic.com',
+      'www.google.co.uk/ads/ga-audiences'
+    ],
+    connectSrc: [
+      'https://www.google-analytics.com',
+      'https://region1.google-analytics.com',
+      'https://region1.analytics.google.com'
+    ]
+  }
 });
 
 // overwrite exclusion_days.json once a day


### PR DESCRIPTION
## What

Add the following CSP rules to service config

imgSrc: [
      'www.google-analytics.com',
      'ssl.gstatic.com',
      'www.google.co.uk/ads/ga-audiences'
    ],
    connectSrc: [
      'https://www.google-analytics.com',
      'https://region1.google-analytics.com',
      'https://region1.analytics.google.com'
    ]

## Why

Support new GA analytics domain from https://region1.analytics.google.com to https://region1.google-analytics.com
