### PR TITLE
ARE-108: test GA on latest hof version

### DIFF
--- a/apps/are_form/data/exclusion_days.json
+++ b/apps/are_form/data/exclusion_days.json
@@ -4,62 +4,6 @@
     "events": [
       {
         "title": "New Year’s Day",
-        "date": "2017-01-02",
-        "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "Monday 02 January 2017"
-      },
-      {
-        "title": "Good Friday",
-        "date": "2017-04-14",
-        "notes": "",
-        "bunting": false,
-        "formattedDate": "Friday 14 April 2017"
-      },
-      {
-        "title": "Easter Monday",
-        "date": "2017-04-17",
-        "notes": "",
-        "bunting": true,
-        "formattedDate": "Monday 17 April 2017"
-      },
-      {
-        "title": "Early May bank holiday",
-        "date": "2017-05-01",
-        "notes": "",
-        "bunting": true,
-        "formattedDate": "Monday 01 May 2017"
-      },
-      {
-        "title": "Spring bank holiday",
-        "date": "2017-05-29",
-        "notes": "",
-        "bunting": true,
-        "formattedDate": "Monday 29 May 2017"
-      },
-      {
-        "title": "Summer bank holiday",
-        "date": "2017-08-28",
-        "notes": "",
-        "bunting": true,
-        "formattedDate": "Monday 28 August 2017"
-      },
-      {
-        "title": "Christmas Day",
-        "date": "2017-12-25",
-        "notes": "",
-        "bunting": true,
-        "formattedDate": "Monday 25 December 2017"
-      },
-      {
-        "title": "Boxing Day",
-        "date": "2017-12-26",
-        "notes": "",
-        "bunting": true,
-        "formattedDate": "Tuesday 26 December 2017"
-      },
-      {
-        "title": "New Year’s Day",
         "date": "2018-01-01",
         "notes": "",
         "bunting": true,
@@ -381,6 +325,13 @@
         "formattedDate": "Monday 01 May 2023"
       },
       {
+        "title": "Bank holiday for the coronation of King Charles III",
+        "date": "2023-05-08",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Monday 08 May 2023"
+      },
+      {
         "title": "Spring bank holiday",
         "date": "2023-05-29",
         "notes": "",
@@ -407,75 +358,124 @@
         "notes": "",
         "bunting": true,
         "formattedDate": "Tuesday 26 December 2023"
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2024-01-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Monday 01 January 2024"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2024-03-29",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "Friday 29 March 2024"
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2024-04-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Monday 01 April 2024"
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2024-05-06",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Monday 06 May 2024"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2024-05-27",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Monday 27 May 2024"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2024-08-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Monday 26 August 2024"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2024-12-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Wednesday 25 December 2024"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2024-12-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Thursday 26 December 2024"
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2025-01-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Wednesday 01 January 2025"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2025-04-18",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "Friday 18 April 2025"
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2025-04-21",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Monday 21 April 2025"
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2025-05-05",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Monday 05 May 2025"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2025-05-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Monday 26 May 2025"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2025-08-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Monday 25 August 2025"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2025-12-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Thursday 25 December 2025"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2025-12-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Friday 26 December 2025"
       }
     ]
   },
   "scotland": {
     "division": "scotland",
     "events": [
-      {
-        "title": "2nd January",
-        "date": "2017-01-02",
-        "notes": "",
-        "bunting": true,
-        "formattedDate": "Monday 02 January 2017"
-      },
-      {
-        "title": "New Year’s Day",
-        "date": "2017-01-03",
-        "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "Tuesday 03 January 2017"
-      },
-      {
-        "title": "Good Friday",
-        "date": "2017-04-14",
-        "notes": "",
-        "bunting": false,
-        "formattedDate": "Friday 14 April 2017"
-      },
-      {
-        "title": "Early May bank holiday",
-        "date": "2017-05-01",
-        "notes": "",
-        "bunting": true,
-        "formattedDate": "Monday 01 May 2017"
-      },
-      {
-        "title": "Spring bank holiday",
-        "date": "2017-05-29",
-        "notes": "",
-        "bunting": true,
-        "formattedDate": "Monday 29 May 2017"
-      },
-      {
-        "title": "Summer bank holiday",
-        "date": "2017-08-07",
-        "notes": "",
-        "bunting": true,
-        "formattedDate": "Monday 07 August 2017"
-      },
-      {
-        "title": "St Andrew’s Day",
-        "date": "2017-11-30",
-        "notes": "",
-        "bunting": true,
-        "formattedDate": "Thursday 30 November 2017"
-      },
-      {
-        "title": "Christmas Day",
-        "date": "2017-12-25",
-        "notes": "",
-        "bunting": true,
-        "formattedDate": "Monday 25 December 2017"
-      },
-      {
-        "title": "Boxing Day",
-        "date": "2017-12-26",
-        "notes": "",
-        "bunting": true,
-        "formattedDate": "Tuesday 26 December 2017"
-      },
       {
         "title": "New Year’s Day",
         "date": "2018-01-01",
@@ -834,6 +834,13 @@
         "formattedDate": "Monday 01 May 2023"
       },
       {
+        "title": "Bank holiday for the coronation of King Charles III",
+        "date": "2023-05-08",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Monday 08 May 2023"
+      },
+      {
         "title": "Spring bank holiday",
         "date": "2023-05-29",
         "notes": "",
@@ -867,82 +874,138 @@
         "notes": "",
         "bunting": true,
         "formattedDate": "Tuesday 26 December 2023"
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2024-01-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Monday 01 January 2024"
+      },
+      {
+        "title": "2nd January",
+        "date": "2024-01-02",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Tuesday 02 January 2024"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2024-03-29",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "Friday 29 March 2024"
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2024-05-06",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Monday 06 May 2024"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2024-05-27",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Monday 27 May 2024"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2024-08-05",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Monday 05 August 2024"
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2024-12-02",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "Monday 02 December 2024"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2024-12-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Wednesday 25 December 2024"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2024-12-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Thursday 26 December 2024"
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2025-01-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Wednesday 01 January 2025"
+      },
+      {
+        "title": "2nd January",
+        "date": "2025-01-02",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Thursday 02 January 2025"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2025-04-18",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "Friday 18 April 2025"
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2025-05-05",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Monday 05 May 2025"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2025-05-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Monday 26 May 2025"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2025-08-04",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Monday 04 August 2025"
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2025-12-01",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "Monday 01 December 2025"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2025-12-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Thursday 25 December 2025"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2025-12-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Friday 26 December 2025"
       }
     ]
   },
   "northern-ireland": {
     "division": "northern-ireland",
     "events": [
-      {
-        "title": "New Year’s Day",
-        "date": "2017-01-02",
-        "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "Monday 02 January 2017"
-      },
-      {
-        "title": "St Patrick’s Day",
-        "date": "2017-03-17",
-        "notes": "",
-        "bunting": true,
-        "formattedDate": "Friday 17 March 2017"
-      },
-      {
-        "title": "Good Friday",
-        "date": "2017-04-14",
-        "notes": "",
-        "bunting": false,
-        "formattedDate": "Friday 14 April 2017"
-      },
-      {
-        "title": "Easter Monday",
-        "date": "2017-04-17",
-        "notes": "",
-        "bunting": true,
-        "formattedDate": "Monday 17 April 2017"
-      },
-      {
-        "title": "Early May bank holiday",
-        "date": "2017-05-01",
-        "notes": "",
-        "bunting": true,
-        "formattedDate": "Monday 01 May 2017"
-      },
-      {
-        "title": "Spring bank holiday",
-        "date": "2017-05-29",
-        "notes": "",
-        "bunting": true,
-        "formattedDate": "Monday 29 May 2017"
-      },
-      {
-        "title": "Battle of the Boyne (Orangemen’s Day)",
-        "date": "2017-07-12",
-        "notes": "",
-        "bunting": false,
-        "formattedDate": "Wednesday 12 July 2017"
-      },
-      {
-        "title": "Summer bank holiday",
-        "date": "2017-08-28",
-        "notes": "",
-        "bunting": true,
-        "formattedDate": "Monday 28 August 2017"
-      },
-      {
-        "title": "Christmas Day",
-        "date": "2017-12-25",
-        "notes": "",
-        "bunting": true,
-        "formattedDate": "Monday 25 December 2017"
-      },
-      {
-        "title": "Boxing Day",
-        "date": "2017-12-26",
-        "notes": "",
-        "bunting": true,
-        "formattedDate": "Tuesday 26 December 2017"
-      },
       {
         "title": "New Year’s Day",
         "date": "2018-01-01",
@@ -1343,6 +1406,13 @@
         "formattedDate": "Monday 01 May 2023"
       },
       {
+        "title": "Bank holiday for the coronation of King Charles III",
+        "date": "2023-05-08",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Monday 08 May 2023"
+      },
+      {
         "title": "Spring bank holiday",
         "date": "2023-05-29",
         "notes": "",
@@ -1376,25 +1446,150 @@
         "notes": "",
         "bunting": true,
         "formattedDate": "Tuesday 26 December 2023"
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2024-01-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Monday 01 January 2024"
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2024-03-18",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "Monday 18 March 2024"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2024-03-29",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "Friday 29 March 2024"
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2024-04-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Monday 01 April 2024"
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2024-05-06",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Monday 06 May 2024"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2024-05-27",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Monday 27 May 2024"
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2024-07-12",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "Friday 12 July 2024"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2024-08-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Monday 26 August 2024"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2024-12-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Wednesday 25 December 2024"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2024-12-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Thursday 26 December 2024"
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2025-01-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Wednesday 01 January 2025"
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2025-03-17",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Monday 17 March 2025"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2025-04-18",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "Friday 18 April 2025"
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2025-04-21",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Monday 21 April 2025"
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2025-05-05",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Monday 05 May 2025"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2025-05-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Monday 26 May 2025"
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2025-07-14",
+        "notes": "Substitute day",
+        "bunting": false,
+        "formattedDate": "Monday 14 July 2025"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2025-08-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Monday 25 August 2025"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2025-12-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Thursday 25 December 2025"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2025-12-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "Friday 26 December 2025"
       }
     ]
   },
   "additionalExclusionDates": [
-    {
-      "date": "2017-12-27",
-      "title": "Excluded Day",
-      "formattedDate": "Wednesday 27 December 2017"
-    },
-    {
-      "date": "2017-12-28",
-      "title": "Excluded Day",
-      "formattedDate": "Thursday 28 December 2017"
-    },
-    {
-      "date": "2017-12-29",
-      "title": "Excluded Day",
-      "formattedDate": "Friday 29 December 2017"
-    },
     {
       "date": "2018-12-27",
       "title": "Excluded Day",
@@ -1484,6 +1679,36 @@
       "date": "2023-12-29",
       "title": "Excluded Day",
       "formattedDate": "Friday 29 December 2023"
+    },
+    {
+      "date": "2024-12-27",
+      "title": "Excluded Day",
+      "formattedDate": "Friday 27 December 2024"
+    },
+    {
+      "date": "2024-12-30",
+      "title": "Excluded Day",
+      "formattedDate": "Monday 30 December 2024"
+    },
+    {
+      "date": "2024-12-31",
+      "title": "Excluded Day",
+      "formattedDate": "Tuesday 31 December 2024"
+    },
+    {
+      "date": "2025-12-29",
+      "title": "Excluded Day",
+      "formattedDate": "Monday 29 December 2025"
+    },
+    {
+      "date": "2025-12-30",
+      "title": "Excluded Day",
+      "formattedDate": "Tuesday 30 December 2025"
+    },
+    {
+      "date": "2025-12-31",
+      "title": "Excluded Day",
+      "formattedDate": "Wednesday 31 December 2025"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "author": "HomeOffice",
   "dependencies": {
     "axios": "^0.26.0",
-    "hof": "^20.2.1",
+    "hof": "~20.2.28",
     "jquery": "^3.6.0",
     "lodash": "^4.17.21",
     "moment": "^2.29.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1481,7 +1481,7 @@ crypto-browserify@^3.0.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
-csrf@^3.0.2:
+csrf@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/csrf/-/csrf-3.1.0.tgz#ec75e9656d004d674b8ef5ba47b41fbfd6cb9c30"
   integrity sha512-uTqEnCvWRk042asU6JtapDTcJeeailFy4ydOQS28bj1hcLnYRiqi8SsD2jS412AY1I/4qdOwWZun774iqywf9w==
@@ -2744,10 +2744,10 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hof@^20.2.1:
-  version "20.2.3"
-  resolved "https://registry.yarnpkg.com/hof/-/hof-20.2.3.tgz#b2d94f5aa5be68beaa59cc99030662dca6c2cf1b"
-  integrity sha512-fAuM55vwKHbgoT0hskc/h4dIVj0fgHR1u0E9aJPpW/OxEztIKY+Z1reKxmHJ/XXmUC/6IztigFxe0ryQwx/4Nw==
+hof@~20.2.28:
+  version "20.2.28"
+  resolved "https://registry.yarnpkg.com/hof/-/hof-20.2.28.tgz#349b12321b67bcc337fb09c3ea79c863ce5b440c"
+  integrity sha512-K1abZdRen3snVsjTronpOTEPz+9cYq5B3u2TBtoFmPZ3qF8O0vpvGAdbPkp04qJvP74IeN/l+/WOeHTfrau4Aw==
   dependencies:
     aliasify "^2.1.0"
     bluebird "^3.7.2"
@@ -2759,7 +2759,7 @@ hof@^20.2.1:
     connect-redis "^5.2.0"
     cookie-parser "^1.4.6"
     cp "^0.2.0"
-    csrf "^3.0.2"
+    csrf "^3.1.0"
     debug "^4.3.1"
     deprecate "^1.0.0"
     dotenv "^4.0.0"
@@ -2788,9 +2788,9 @@ hof@^20.2.1:
     mixwith "^0.1.1"
     moment "^2.29.4"
     morgan "^1.10.0"
-    mustache "^2.3.0"
+    mustache "^4.2.0"
     nodemailer "^6.6.3"
-    nodemailer-ses-transport "^1.5.0"
+    nodemailer-ses-transport "^1.5.1"
     nodemailer-smtp-transport "^2.7.4"
     nodemailer-stub-transport "^1.1.0"
     notifications-node-client "^6.0.0"
@@ -2801,7 +2801,7 @@ hof@^20.2.1:
     sass "^1.56.2"
     serve-static "^1.14.1"
     uglify-js "^3.14.3"
-    underscore "^1.12.1"
+    underscore "^1.13.6"
     urijs "^1.19.11"
     uuid "^8.3.2"
     winston "^3.7.2"
@@ -3774,10 +3774,10 @@ ms@2.1.3, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-mustache@^2.3.0:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/mustache/-/mustache-2.3.2.tgz#a6d4d9c3f91d13359ab889a812954f9230a3d0c5"
-  integrity sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==
+mustache@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.2.0.tgz#e5892324d60a12ec9c2a73359edca52972bf6f64"
+  integrity sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==
 
 nanoid@3.3.1:
   version "3.3.1"
@@ -3838,7 +3838,7 @@ nodemailer-fetch@1.6.0:
   resolved "https://registry.yarnpkg.com/nodemailer-fetch/-/nodemailer-fetch-1.6.0.tgz#79c4908a1c0f5f375b73fe888da9828f6dc963a4"
   integrity sha512-P7S5CEVGAmDrrpn351aXOLYs1R/7fD5NamfMCHyi6WIkbjS2eeZUB/TkuvpOQr0bvRZicVqo59+8wbhR3yrJbQ==
 
-nodemailer-ses-transport@^1.5.0:
+nodemailer-ses-transport@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/nodemailer-ses-transport/-/nodemailer-ses-transport-1.5.1.tgz#dc0598c1bf53e8652e632e8f31692ce022d7dea9"
   integrity sha512-JwL93Lc7KEWbH4a9Ehm6XCJgNhf6QNleSDkIsCvEyViKzqvYsf+8rF2PG8OzI1xDyxvtgsaWAmJWMqABOZmnWg==
@@ -5224,7 +5224,7 @@ undeclared-identifiers@^1.1.2:
     simple-concat "^1.0.0"
     xtend "^4.0.1"
 
-underscore@^1.12.1, underscore@^1.7.0, underscore@^1.8.2, underscore@~1.7.0:
+underscore@^1.12.1, underscore@^1.13.6, underscore@^1.7.0, underscore@^1.8.2, underscore@~1.7.0:
   version "1.13.6"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
   integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==


### PR DESCRIPTION
## What?
Upgrade hof from v20.2.1 to v20.2.28 (gtm-beta)

## Why?
Test that this hof upgrade (intended for ETA) works fine in other forms with no issues

## How?

## Testing?

