### PR TITLE
HOFF-999 setting nginx rate limiter - ARE as a test

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,7 @@ environment:
   IMAGE_URL: quay.io/ukhomeofficedigital
   IMAGE_REPO: are-app
   GIT_REPO: UKHomeOffice/AppealRightsExhausted
-  HOF_CONFIG: hof-services-config/Appeal_Rights_Exhausted
+  HOF_CONFIG: hof-services-config/Appeal_Rights_Exhausted/HOFF-999
   NON_PROD_AVAILABILITY: Mon-Fri 08:00-23:00 Europe/London
   READY_FOR_TEST_DELAY: 20s
   NOTIFY_STUB: stub

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 A calculator to determine Appeal Rights Exhausted
 
 # Setup
+# Comment to trigger a build to test nginx ratew limiter on the nginx deployment
 
 ## Install prerequisites
 


### PR DESCRIPTION
What?
Rate limiting no nginx

Why?
Rate limiting with NGINX Ingress Controller in Kubernetes allows you to control the number of requests a client can make to your application within a specific time frame. This helps prevent abuse, improves application stability, and ensures fair usage of resources.

How?
Setting the ingress controller setting

Testing?
Nginx throttling on the site

Anything Else? (optional)
