### PR TITLE
ARE-140: Fixed Incorrect exclusion dates showing for countries outsid…

### DIFF
--- a/apps/are_form/behaviours/result.js
+++ b/apps/are_form/behaviours/result.js
@@ -11,7 +11,7 @@ module.exports = superclass => class ReferenceList extends superclass {
   getValues(req, res, callback) {
     super.getValues(req, res, async err => {
       const json = req.sessionModel.toJSON();
-      const exclusionDates = new ExclusionDates();
+      const exclusionDates = new ExclusionDates(json['country-of-hearing']);
       await exclusionDates.fetchExcludedDates();
 
       const calculator = new ARECalculator(


### PR DESCRIPTION
…e England/Wales.

## What?
Incorrect exclusion dates showing for countries outside England/Wales. [ARE-140](https://collaboration.homeoffice.gov.uk/jira/browse/ARE-140)
## Why? 
An instance of the ExclusionDates class is not passed the user selected country before the fetchExcludedDates() function is called to fetch exclusion dates for that specific country.
## How? 
Passed the "json['country-of-hearing']" property value to the ExclusionDates object's constructor during instantiation within the "result.js" file.
## Testing?
Manual testing conducted to check the correct exclusion dates are appeared.
## Screenshots (optional)
<img width="451" alt="image" src="https://github.com/user-attachments/assets/ac7c0916-744e-47e5-afae-16162e63dfc5" />

## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
