### PR TITLE
HOFF-308: Test Redis Image with fixed vuln  on ARE

### DIFF
--- a/kube/redis/redis-deployment.yml
+++ b/kube/redis/redis-deployment.yml
@@ -32,7 +32,7 @@ spec:
       containers:
         - name: redis
           # redis:v7.0.15-1
-          image: quay.io/ukhomeofficedigital/hof-docker-redis:a94152bc40b0ddb6ed9cb4fec3cc2c7a51c172c1
+          image: quay.io/ukhomeofficedigital/hof-docker-redis:1af6ea46456860379b5fe62b4c54df9746e53ff8
           ports:
             - containerPort: 6379
           volumeMounts:

--- a/kube/redis/redis-deployment.yml
+++ b/kube/redis/redis-deployment.yml
@@ -31,8 +31,8 @@ spec:
     spec:
       containers:
         - name: redis
-          # redis:v5.0.6-1
-          image: quay.io/ukhomeofficedigital/hof-docker-redis@sha256:61b31c68c30de6211f55c3d0c2a7454f932bff08c55adf1fa4ea1bc580c86f1c
+          # redis:v7.0.15-1
+          image: quay.io/ukhomeofficedigital/hof-docker-redis:a94152bc40b0ddb6ed9cb4fec3cc2c7a51c172c1
           ports:
             - containerPort: 6379
           volumeMounts:

--- a/kube/redis/redis-deployment.yml
+++ b/kube/redis/redis-deployment.yml
@@ -32,7 +32,7 @@ spec:
       containers:
         - name: redis
           # redis:v5.0.6-1
-          image: quay.io/ukhomeofficedigital/redis@sha256:4499ea7306de776dab2ba8befd723a419fd311519d6f91f7821ed1a7c589da3b
+          image: quay.io/ukhomeofficedigital/hof-docker-redis@sha256:61b31c68c30de6211f55c3d0c2a7454f932bff08c55adf1fa4ea1bc580c86f1c
           ports:
             - containerPort: 6379
           volumeMounts:


### PR DESCRIPTION
### WHAT?
Fix vulnerabilities in Image
Upgrade to latest stable version of REDIS i.e Redis v 7.0.15-1
refer to PR https://github.com/UKHomeOffice/hof-docker-redis/pull/3
### WHY?
Current image has vulnerabilities that needs to be fixed
Base image Fedora is unsupported by Trivy and SNYK

### HOW?
New image has.....

1. Upgraded/patch the packages that come with base image to ensure the vulnerabilties are fixed in base image 
2. Update to use the HOF Drone pipeline
3. Add Ignore files for docker, drone and git
4. After Merging to Master use Git tags ( see Readme) it will deploy image to Quay with tags which will be final image to use in HOF services

TESTING?
Test on ARE - [ ]
<img width="212" alt="image" src="https://github.com/user-attachments/assets/e02c16c1-3755-41b0-b13a-abee5a6e939e" />


ANYTHING ELSE?

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
