### PR TITLE
fixing tear down step

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -9,6 +9,7 @@ export NGINX_SETTINGS=$HOF_CONFIG/nginx-settings.yaml
 kd='kd --insecure-skip-tls-verify --timeout 10m --check-interval 10s'
 redis_storage_files='kube/redis/redis-persistent-volume-claim.yml'
 redis_runtime_files='kube/redis/redis-service.yml -f kube/redis/redis-network-policy.yml -f kube/redis/redis-deployment.yml'
+export REDIS_STORAGE_CLASS=${REDIS_STORAGE_CLASS:-gp2-encrypted-eu-west-2b}
 
 if [[ $1 == 'tear_down' ]]; then
   export KUBE_NAMESPACE=$BRANCH_ENV
@@ -22,7 +23,6 @@ fi
 
 export KUBE_NAMESPACE=$1
 export DRONE_SOURCE_BRANCH=$(echo $DRONE_SOURCE_BRANCH | tr '[:upper:]' '[:lower:]' | tr '/' '-')
-export REDIS_STORAGE_CLASS=${REDIS_STORAGE_CLASS:-gp2-encrypted-eu-west-2b}
 
 if [[ ${REDIS_PVC_RECREATE} == "true" ]]; then
   $kd --delete -f kube/redis/redis-persistent-volume-claim.yml || true


### PR DESCRIPTION
## What? 
Fixing tear down step

## Why? 

2026/03/20 14:10:55 skipping delete for resource (xxx-(#200)) as it does not exist.
[ERROR] 2026/03/20 14:10:55 main.go:248: template: template:12:23: executing "template" at <.REDIS_STORAGE_CLASS>: map has no entry for key "REDIS_STORAGE_CLASS"

## How? 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
