### PR TITLE
HOFF-2068-ARE-PVC-Correction

### DIFF
--- a/kube/redis/redis-deployment.yml
+++ b/kube/redis/redis-deployment.yml
@@ -9,6 +9,8 @@ metadata:
   {{ end }}
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}


### PR DESCRIPTION
## What?
This pull request makes a small but important change to the Redis deployment configuration. The deployment strategy is now explicitly set to `Recreate`, which ensures that all existing pods are terminated before new ones are created during updates.

* Set the deployment `strategy` to `Recreate` in `redis-deployment.yml` to avoid issues with multiple Redis pods running simultaneously.

## Why?
To prevent 
`Warning  FailedAttachVolume  4m40s                attachdetach-controller  Multi-Attach error for volume "pvc-925ebb44-8f88-45d3-8c58-8a33cef9294f" Volume is already used by pod(s) redis-node-pvc-fix-6bd7dc8d8d-9qjx8
  Warning  FailedMount         20s (x2 over 2m37s)  kubelet                  Unable to attach or mount volumes: unmounted volumes=[data], unattached volumes=[data default-token-rgpgj]: timed out waiting for the condition `

## How?
Change the strategy in redis deploy

## Testing?
Manual - delete and redeploy pod

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
